### PR TITLE
fix(header): Update notice button props

### DIFF
--- a/src/ui/containers/Header.tsx
+++ b/src/ui/containers/Header.tsx
@@ -113,7 +113,7 @@ const Header: React.FC<HeaderProps> = ({ title, sidebarFn }) => {
 			<RightGroup>
 				<Search />
 				<ButtonIcon icon="settings" label="Open Settings" />
-				<ButtonIcon icon="notification" label="Open Notification" dark />
+				<ButtonIcon icon="notification" label="Open Notification" />
 				<User image="https://i.pravatar.cc/300" />
 			</RightGroup>
 		</Container>


### PR DESCRIPTION
The current button has a dark look not matching with the Figma design. To resolve this is necessary to remove the “dark” prop.